### PR TITLE
Add /robots.txt to path

### DIFF
--- a/env/dev/values.yaml
+++ b/env/dev/values.yaml
@@ -7,3 +7,4 @@ nginxingress:
   hosts:
     - name: dev.p4.greenpeace.org
       tls: true
+      path: robots.txt

--- a/env/dev/values.yaml
+++ b/env/dev/values.yaml
@@ -1,5 +1,6 @@
 ---
 hostname: www-dev.greenpeace.org
+hostpath: robots.txt
 ingress:
   hosts:
     - name: dev.p4.greenpeace.org

--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -1,5 +1,6 @@
 ---
 hostname: master.k8s.p4.greenpeace.org
+hostpath: robots.txt
 ingress:
   hosts:
     - name: release.k8s.p4.greenpeace.org
@@ -10,11 +11,16 @@ nginxingress:
   hosts:
     - name: release.k8s.p4.greenpeace.org
       tls: true
+      path: robots.txt
     - name: prod.p4.greenpeace.org
       tls: true
+      path: robots.txt
     - name: release.p4.greenpeace.org
       tls: true
+      path: robots.txt
     - name: prod.nginx.p4.greenpeace.org
       tls: true
+      path: robots.txt
     - name: master.k8s.p4.greenpeace.org
       tls: true
+      path: robots.txt


### PR DESCRIPTION
This updates the paths to the ingress so anyone navigating to master.k8s.p4.greenpeace.org gets a 404 instead of a 200 and a blank page. robots.txt will still be available at /robots.txt