### PR TITLE
Update chart version to use alpha version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/bash
 NAMESPACE ?= default
 RELEASE_NAME ?= p4-robots
 CHART_NAME ?= p4/static
+CHART_VERSION ?= 0.3.8-alpha
 
 DEV_CLUSTER ?= p4-development
 DEV_PROJECT ?= planet-4-151612
@@ -80,6 +81,7 @@ endif
 		--namespace=$(NAMESPACE) \
 		--values values.yaml \
 		--values env/dev/values.yaml \
+		--version "$(CHART_VERSION)" \
 		--set openresty.geoip.accountid=$(GEOIP_ACCOUNTID) \
 		--set openresty.geoip.license=$(GEOIP_LICENSE)
 

--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -1,5 +1,6 @@
 ---
 hostname: master.k8s.p4.greenpeace.org
+hosttls: true
 ingress:
   hosts:
     - name: release.k8s.p4.greenpeace.org


### PR DESCRIPTION
Updates chart version in dev to use alpha - this is for final testing of an update to the static helm chart to allow LE certs on the hostname parameter using .Values.hosttls as a switch.

This is to fix master.k8s.p4.greenpeace.org cert error.