### PR TITLE
Add a liveness delay

### DIFF
--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -22,6 +22,3 @@ nginxingress:
     - name: prod.nginx.p4.greenpeace.org
       tls: true
       path: robots.txt
-    - name: master.k8s.p4.greenpeace.org
-      tls: true
-      path: robots.txt

--- a/values.yaml
+++ b/values.yaml
@@ -12,3 +12,5 @@ openresty:
     license: ""
   cloudflare:
     enabled: false
+healthProbes:
+  livenessDelay: 60


### PR DESCRIPTION
Sometime when deploying robots the setup period takes a long time - therefore we add a liveness delay so k8s won't try and restart the pod early resulting in the deployment failing.

This PR also removes an unnecessary master.k8s.p4.greenpeace.org host entry (which was added to trigger a cert generation and isn't needed anymore now we are using the new static chart)